### PR TITLE
Fix: crashes because delegate not cleaned up properly

### DIFF
--- a/CCNode+SFGestureRecognizers/CCNode+SFGestureRecognizers.m
+++ b/CCNode+SFGestureRecognizers/CCNode+SFGestureRecognizers.m
@@ -347,8 +347,9 @@ static NSString *const UIGestureRecognizerSFGestureRecognizersPassingDelegateKey
   //! remove dealloc block
   __SFGestureRecognizersPassingDelegate *delegate = objc_getAssociatedObject(aGestureRecognizer, AH_BRIDGE(UIGestureRecognizerSFGestureRecognizersPassingDelegateKey));
   objc_setAssociatedObject(gestureRecognizers, delegate->deallocBlockKey, nil, OBJC_ASSOCIATION_ASSIGN);
-
-  objc_setAssociatedObject(self, AH_BRIDGE(UIGestureRecognizerSFGestureRecognizersPassingDelegateKey), nil, OBJC_ASSOCIATION_RETAIN);
+  aGestureRecognizer.delegate = nil;
+    
+  objc_setAssociatedObject(aGestureRecognizer, AH_BRIDGE(UIGestureRecognizerSFGestureRecognizersPassingDelegateKey), nil, OBJC_ASSOCIATION_RETAIN);
   if ([[CCDirector sharedDirector] respondsToSelector:@selector(view)]) {
     [[[CCDirector sharedDirector] performSelector:@selector(view)] removeGestureRecognizer:aGestureRecognizer];
   } else {

--- a/CCNode+SFGestureRecognizers/CCNode+SFGestureRecognizers.m
+++ b/CCNode+SFGestureRecognizers/CCNode+SFGestureRecognizers.m
@@ -316,6 +316,7 @@ static NSString *const UIGestureRecognizerSFGestureRecognizersPassingDelegateKey
   //! remove this gesture recognizer from view when array is deallocatd
   __unsafe_unretained __block CCNode *weakSelf = self;
   void *key = AH_BRIDGE([__SFExecuteOnDealloc executeBlock:^{
+     aGestureRecognizer.delegate = nil;
 #if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
     [weakSelf removeGestureRecognizer:aGestureRecognizer];
 #else
@@ -347,9 +348,11 @@ static NSString *const UIGestureRecognizerSFGestureRecognizersPassingDelegateKey
   //! remove dealloc block
   __SFGestureRecognizersPassingDelegate *delegate = objc_getAssociatedObject(aGestureRecognizer, AH_BRIDGE(UIGestureRecognizerSFGestureRecognizersPassingDelegateKey));
   objc_setAssociatedObject(gestureRecognizers, delegate->deallocBlockKey, nil, OBJC_ASSOCIATION_ASSIGN);
-  aGestureRecognizer.delegate = nil;
     
+  id realDelegate = delegate->originalDelegate;
   objc_setAssociatedObject(aGestureRecognizer, AH_BRIDGE(UIGestureRecognizerSFGestureRecognizersPassingDelegateKey), nil, OBJC_ASSOCIATION_RETAIN);
+  aGestureRecognizer.delegate = realDelegate;
+    
   if ([[CCDirector sharedDirector] respondsToSelector:@selector(view)]) {
     [[[CCDirector sharedDirector] performSelector:@selector(view)] removeGestureRecognizer:aGestureRecognizer];
   } else {


### PR DESCRIPTION
Hi,

First, I'd like to thank you for creating this great pod for cocos2d. It is really great. :)

While I was testing it in my prototype app I stumbled upon occasional crashes during scene transition. (BTW: I've used CCNode-SFGestureRecognizers along with other pods like cocos2d and without ARC.)
I've investigated the problem and found that removeGestureRecognizer: did not clean up properly aGestureRecognizer.delegate. In addition there was an incorrect call "objc_setAssociatedObject(self, AH_BRIDGE(UIGestureRecognizerSFGestureRecognizersPassingDelegateKey), nil, OBJC_ASSOCIATION_RETAIN);" Here the problem was that the method should use aGestureRecognizer instead of self. Probably it was a typo.

Anyway, not setting aGestureRecognizer.delegate to nil caused that originalDelegate member of __SFGestureRecognizersPassingDelegate was not set to nil as well and in some cases after the removeGestureRecognizer called __SFGestureRecognizersPassingDelegate object still has received gestureRecognizerShouldBegin callback. The gestureRecognizerShouldBegin callback was referring to originalDelegate and it caused a crash.

The changes I propose fix this problem. (Maybe in ARC case this problem wouldn't surface since is a weak pointer so it will be reset to nil upon it is released.)
